### PR TITLE
APIの返却値を待つように修正

### DIFF
--- a/lib/wbench.rb
+++ b/lib/wbench.rb
@@ -26,7 +26,7 @@ require 'wbench/version'
 
 module WBench
   CAPYBARA_DRIVER  = :wbench_browser
-  CAPYBARA_TIMEOUT = 60
+  CAPYBARA_TIMEOUT = 300
   DEFAULT_LOOPS    = 10
   DEFAULT_BROWSER  = :chrome
 

--- a/lib/wbench/browser.rb
+++ b/lib/wbench/browser.rb
@@ -69,8 +69,24 @@ module WBench
 
     def wait_for_page
       Selenium::WebDriver::Wait.new(:timeout => CAPYBARA_TIMEOUT).until do
-        session.evaluate_script('window.performance.timing.loadEventEnd').to_i > 0
+        is_finished_load_event_end = session.evaluate_script('window.performance.timing.loadEventEnd').to_i > 0
+        ( is_finished_load_event_end && is_finished_mark )
       end
+    end
+
+    def is_finished_mark
+        marks = session.evaluate_script('window.performance.getEntriesByType("mark")')
+        start_count = 0
+        finished_count = 0
+        marks.each do |mark|
+          case mark['name']
+          when /^(Start:)/
+            start_count = start_count + 1
+          when /^(Finished:)/
+            finished_count = finished_count + 1
+          end
+        end
+        ( start_count === finished_count )
     end
 
     def set_cookies


### PR DESCRIPTION
# Summary
- 現状 `window.performance.timing.loadEventEnd'` のタイミングまでしか待ってくれない為、
  APIで投げている `mark` で `Start`  と同じ数の `Finished` があるまで、待つよう修正しました。
- こちらは、torchlightのみに適用の差分です。
- タイムアウトも60秒から300秒に修正しました。
# ！！！注意！！！
- マージ後ブランチを削除しないで下さい。
- Sherpa本体側の差分を修正次第削除致しますmm
