### PR TITLE
[bug] APIの返却時の時間を計測するように修正

### DIFF
--- a/lib/wbench/browser.rb
+++ b/lib/wbench/browser.rb
@@ -70,8 +70,16 @@ module WBench
     def wait_for_page
       Selenium::WebDriver::Wait.new(:timeout => CAPYBARA_TIMEOUT).until do
         is_finished_load_event_end = session.evaluate_script('window.performance.timing.loadEventEnd').to_i > 0
-        ( is_finished_load_event_end && is_finished_mark )
+        ( is_finished_load_event_end && is_finished_mark_process )
       end
+    end
+
+    def is_finished_mark_process
+      loop do
+        sleep 1
+        break if is_finished_mark
+      end
+      true
     end
 
     def is_finished_mark
@@ -81,9 +89,9 @@ module WBench
         marks.each do |mark|
           case mark['name']
           when /^(Start:)/
-            start_count = start_count + 1
+            start_count += 1
           when /^(Finished:)/
-            finished_count = finished_count + 1
+            finished_count += 1
           end
         end
         ( start_count === finished_count )


### PR DESCRIPTION
# 概要
- APIの戻り値が計測できていなかったので、できるように修正しました。
- 永久ループの件は対応すると計測できなくなってしまうので。。。ちょっと保留してます。
# 確認方法
- このブランチををチェックアウトしてきてください。
- Ibiza側のGemfaileを修正して、bundle installして下さい。

``` diff
diff --git a/Gemfile b/Gemfile
index c9e7281..886d305 100644
--- a/Gemfile
+++ b/Gemfile
@@ -111,5 +111,6 @@ group :test, :test_master, :test_development, :test_pull_request, :development d
   gem 'brakeman', :require => false
   gem 'rubocop', require: false
   gem 'json'
-  gem 'wbench', '1.1.1', :git => 'https://github.com/torchlight-dev/wbench.git'
+  # gem 'wbench', '1.1.1', :git => 'https://github.com/torchlight-dev/wbench.git'
+  gem 'wbench', '1.1.1', :path => '../wbench'
 end
```
- 以下を実行して計測できる事を確認して下さい。

```
bundle exec rake wbench:fb:campaign[1,'https://sherpa.to']
```
